### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,5 @@ module "acm" {
     "example.com"     = "XYZXYZXYZXYZXYZ"
     "www.example.com" = "YZXYZXYZXYZXYZX"
   }
-
-  tags = {
-    app  = "some-service"
-    env  = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -12,7 +12,7 @@ module "acm" {
     "www.example.com" = "YZXYZXYZXYZXYZX"
   }
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_acm_certificate" "this" {
   subject_alternative_names = setsubtract(keys(var.domain_names_to_zone_ids), [var.primary_domain_name])
   validation_method         = "DNS"
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.acm_certificate_tags)
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,33 @@
-variable "primary_domain_name" {
-  description = "A domain name for which the certificate should be issued"
-  type        = string
+variable "acm_certificate_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the ACM certificate. Overrides tags set in `var.default_tags`.
+EOS
+}
+
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
 }
 
 variable "domain_names_to_zone_ids" {
-  description = "Map of domain names (incl. `var.primary_domain_name`) to Route53 hosted zone IDs"
-  type        = map(string)
+  type = map(string)
+
+  description = <<EOS
+Map of domain names (incl. `var.primary_domain_name`) to Route53 hosted zone IDs.
+EOS
 }
 
-variable "tags" {
-  description = "A mapping of tags to assign to the resource"
-  type        = map(string)
-  default     = {}
+variable "primary_domain_name" {
+  type = string
+
+  description = <<EOS
+A domain name for which the certificate should be issued.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.