### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,5 @@ module "acm" {
     "example.com"     = "XYZXYZXYZXYZXYZ"
     "www.example.com" = "YZXYZXYZXYZXYZX"
   }
-
-  tags = {
-    app  = "some-service"
-    env  = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -12,7 +12,7 @@ module "acm" {
     "www.example.com" = "YZXYZXYZXYZXYZX"
   }
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_acm_certificate" "this" {
   subject_alternative_names = setsubtract(keys(var.domain_names_to_zone_ids), [var.primary_domain_name])
   validation_method         = "DNS"
 
-  tags = var.tags
+  tags = var.default_tags
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "domain_names_to_zone_ids" {
   type = map(string)
 
@@ -11,14 +20,5 @@ variable "primary_domain_name" {
 
   description = <<EOS
 A domain name for which the certificate should be issued.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.